### PR TITLE
add support for passing RDS CA Certs bundle via AWS secrets manager secret

### DIFF
--- a/docs/resources/aws.md
+++ b/docs/resources/aws.md
@@ -78,6 +78,7 @@ resource "dataplane_aws" "deltastream" {
     workload_credentials_mode = "iamrole"
     workload_role_arn         = "arn:aws:iam::123456789012:role/workload-iam-role"
     workload_manager_role_arn = "arn:aws:iam::123456789012:role/workload-manager-iam-role"
+    rds_ca_certs_secret       = "deltastream/rds/ca/rds-certs-bundle"
   }
 }
 ```
@@ -150,6 +151,7 @@ Required:
 - `product_artifacts_bucket` (String) The S3 bucket for storing DeltaStream product artifacts.
 - `product_version` (String) The version of the DeltaStream product. (provided by DeltaStream)
 - `public_subnet_ids` (List of String) The public subnet IDs with internet gateway.
+- `rds_ca_certs_secret` (String) secret id that stores RDS ca certificates added as base64 json value for each region with json key formatted as rds-certs-{region}-bundle-pem (AWS link containing regional CA certificates: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html#UsingWithRDS.SSL.CertificatesDownload)
 - `rds_resource_id` (String) The resource ID of the RDS instance for storing DeltaStream data.
 - `serde_bucket` (String) The S3 bucket for storing SERDE artifacts.
 - `store_proxy_role_arn` (String) The ARN of the role to assume to facilitate connection to customer stores.

--- a/examples/resources/dataplane_aws/resource.tf
+++ b/examples/resources/dataplane_aws/resource.tf
@@ -63,6 +63,7 @@ resource "dataplane_aws" "deltastream" {
     workload_credentials_mode = "iamrole"
     workload_role_arn         = "arn:aws:iam::123456789012:role/workload-iam-role"
     workload_manager_role_arn = "arn:aws:iam::123456789012:role/workload-manager-iam-role"
+    rds_ca_certs_secret       = "deltastream/rds/ca/rds-certs-bundle"
   }
 }
 

--- a/internal/deltastream/aws/cluster-config.go
+++ b/internal/deltastream/aws/cluster-config.go
@@ -167,6 +167,7 @@ func updateClusterConfig(ctx context.Context, cfg aws.Config, dp awsconfig.AWSDa
 
 			"customCredentialsRoleARN":      []byte(ptr.Deref(config.CustomCredentialsRoleARN.ValueStringPointer(), "")),
 			"enableCustomCredentialsPlugin": []byte(customCredentialsEnabled),
+			"rdsCACertsSecret":              []byte(config.RdsCACertsSecret.ValueString()),
 		}
 		return nil
 	})

--- a/internal/deltastream/aws/config/resource-config.go
+++ b/internal/deltastream/aws/config/resource-config.go
@@ -124,7 +124,8 @@ type ClusterConfiguration struct {
 	ControlPlaneKafkaHosts         basetypes.ListValue `tfsdk:"cp_kafka_hosts"`
 	ControlPlaneKafkaListenerPorts basetypes.ListValue `tfsdk:"cp_kafka_listener_ports"`
 
-	ConsoleHostname basetypes.StringValue `tfsdk:"console_hostname"`
+	ConsoleHostname  basetypes.StringValue `tfsdk:"console_hostname"`
+	RdsCACertsSecret basetypes.StringValue `tfsdk:"rds_ca_certs_secret"`
 }
 
 func (d *AWSDataplane) AssumeRoleData(ctx context.Context) (AssumeRole, diag.Diagnostics) {
@@ -497,6 +498,11 @@ var Schema = schema.Schema{
 					Description: "The hostname of the DeltaStream console",
 					Required:    true,
 					Validators:  []validator.String{stringvalidator.RegexMatches(regexp.MustCompile(`^[a-zA-Z0-9-\.]+\.[a-zA-Z]{2,}$`), "Invalid hostname")},
+				},
+
+				"rds_ca_certs_secret": schema.StringAttribute{
+					Description: "The secret id in AWS secrets manager holding RDS instance AWS CA certificates",
+					Required:    true,
 				},
 			},
 		},


### PR DESCRIPTION
Support for passing RDS CA certs bundle as secrets manager secret.

Secret content should be a json document using following format:


```json

{

   "rds-certs-{DATAPLANE_REGION}-bundle-pem": "{BASE64_PEM_FILE}"

}
```

AWS link to source regional CA bundles : https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html#UsingWithRDS.SSL.CertificatesAllRegions

For example, when creating a data-plane in us-east-1 follow these steps to create secret content:

* Update `{DATAPLANE_REGION}` to `us-east-1`
* Download PEM link for us-east-1 is https://truststore.pki.rds.amazonaws.com/us-east-1/us-east-1-bundle.pem
* After downloading, convert the file content to base64 using:

```

cat us-east-1-bundle.pem | base64 -w 0

```

* Next copy the output base64 string and replace `{BASE64_PEM_FILE}` in the JSON document.

* Upload the content as secret to AWS  secrets manager using a name such as `deltastream/rds/ca-certs` in the same region as data-plane

* Pass the secret id to the data-plane provider using variable `rds_ca_certs_secret`, e.g.    

```
  rds_ca_certs_secret = "deltastream/rds/ca-certs"
```
